### PR TITLE
Feature/eat 56326/Throw chart not found error, retrieve machine ID

### DIFF
--- a/packages/core-persistence/src/PersistenceAdapter.ts
+++ b/packages/core-persistence/src/PersistenceAdapter.ts
@@ -93,7 +93,7 @@ export abstract class PersistenceAdapter<
   protected abstract readChart<TContext, TEvent extends EventObject>(
     ref: ChartReference,
     connection?: ConnectionType,
-  ): Promise<PersistedChart<TContext, TEvent> | null>;
+  ): Promise<PersistedChart<TContext, TEvent>>;
 
   /**
    * @abstract
@@ -472,11 +472,6 @@ export abstract class PersistenceAdapter<
 
     trace({ message: 'Reading chart from the database' });
     const chartRow = await this.readChart<TContext, TEvent>(ref, connection);
-
-    if (!chartRow) {
-      trace({ level: 'warning', message: 'Chart not found in the database' });
-      return null;
-    }
 
     trace({ message: 'Creating state object' });
     const state = State.create<TContext, TEvent>(chartRow.state);

--- a/packages/core-persistence/src/PersistenceAdapter.ts
+++ b/packages/core-persistence/src/PersistenceAdapter.ts
@@ -98,6 +98,13 @@ export abstract class PersistenceAdapter<
   /**
    * @abstract
    */
+  public abstract getChartMachineId<TContext, TEvent extends EventObject>(
+    id: string
+  ): Promise<string>;
+
+  /**
+   * @abstract
+   */
   protected abstract updateChartState<TContext, TEvent extends EventObject>(
     ref: ChartReference,
     serializedState: State<

--- a/packages/core-pg/src/PostgresPersistenceAdapter.ts
+++ b/packages/core-pg/src/PostgresPersistenceAdapter.ts
@@ -6,6 +6,7 @@ import path from 'path';
 import {
   getCorrelationIdentifier,
   ChartNotFoundError,
+  MachineNotFoundError,
   ChartIdentifier,
   ChartReference,
 } from '@samihult/xjog-util';
@@ -387,6 +388,25 @@ export class PostgresPersistenceAdapter extends PersistenceAdapter<PoolClient> {
     return PostgresPersistenceAdapter.parseSqlChartRow<TContext, TEvent>(
       result.rows[0],
     );
+  }
+
+  public async getChartMachineId<TContext, TEvent extends EventObject>(
+    id: string,
+    connection: Pool | PoolClient = this.pool,
+  ): Promise<string> {
+    const result = await connection.query(
+      bind(
+        'SELECT "machineId" FROM "charts" ' +
+        'WHERE "chartId" = :chartId ',
+        { chartId: id },
+      ),
+    );
+
+    if (!result) {
+      throw new MachineNotFoundError(id, "Machine not found in database.")
+    }
+
+    return result.rows[0].machineId;
   }
 
   protected async updateChartState<TContext, TEvent extends EventObject>(

--- a/packages/core-pg/src/PostgresPersistenceAdapter.ts
+++ b/packages/core-pg/src/PostgresPersistenceAdapter.ts
@@ -382,7 +382,7 @@ export class PostgresPersistenceAdapter extends PersistenceAdapter<PoolClient> {
     );
 
     if (!result.rowCount) {
-      throw new ChartNotFoundError(ref, "Chart not found in database.")
+      throw new ChartNotFoundError(ref, 'Chart not found in database.')
     }
 
     return PostgresPersistenceAdapter.parseSqlChartRow<TContext, TEvent>(
@@ -403,7 +403,7 @@ export class PostgresPersistenceAdapter extends PersistenceAdapter<PoolClient> {
     );
 
     if (!result) {
-      throw new MachineNotFoundError(id, "Machine not found in database.")
+      throw new MachineNotFoundError(id, 'Machine not found in database.')
     }
 
     return result.rows[0].machineId;

--- a/packages/core/src/XJog.ts
+++ b/packages/core/src/XJog.ts
@@ -327,7 +327,7 @@ export class XJog extends XJogLogEmitter {
   >(
     ref: ChartReference | URL | string,
     cid = getCorrelationIdentifier(),
-  ): Promise<XJogChart<TContext, TStateSchema, TEvent, TTypeState>> {
+  ): Promise<XJogChart<TContext, TStateSchema, TEvent, TTypeState> | null> {
     const chartIdentifier = ChartIdentifier.from(ref);
     if (chartIdentifier) {
       const machine = this.getMachine<TContext, TStateSchema, TEvent, TTypeState>(
@@ -345,6 +345,18 @@ export class XJog extends XJogLogEmitter {
     } else {
       this.trace({ in: 'getChart', ref, cid }, 'Failed to parse reference');
     }
+    return null;
+  }
+
+  /**
+   * Retrieves the machine ID associated with the given chart.
+   *
+   * @param chartId - The ID of the chart.
+   * @throws {MachineNotFoundError} If the machine associated with the chart is not found.
+   * @returns A promise that resolves to the machine ID.
+   */
+  public async getChartMachineId(chartId: string): Promise<string> {
+    return this.persistence.getChartMachineId(chartId);
   }
 
   public async registerExternalId(

--- a/packages/core/src/XJogChart.ts
+++ b/packages/core/src/XJogChart.ts
@@ -284,7 +284,7 @@ export class XJogChart<
     TEvent,
     TTypeState,
     TEmitted
-  > | null> {
+  >> {
     return xJogMachine.xJog.timeExecution('chart.load', async () => {
       const ref = {
         machineId: xJogMachine.id,
@@ -297,10 +297,6 @@ export class XJogChart<
         TStateSchema,
         TTypeState
       >(ref);
-
-      if (!chart) {
-        return null;
-      }
 
       const { state, parentRef } = chart;
 

--- a/packages/core/src/XJogChart.ts
+++ b/packages/core/src/XJogChart.ts
@@ -284,7 +284,7 @@ export class XJogChart<
     TEvent,
     TTypeState,
     TEmitted
-  >> {
+  > | null> {
     return xJogMachine.xJog.timeExecution('chart.load', async () => {
       const ref = {
         machineId: xJogMachine.id,
@@ -298,21 +298,24 @@ export class XJogChart<
         TTypeState
       >(ref);
 
-      const { state, parentRef } = chart;
+      if (chart) {
+        const { state, parentRef } = chart;
 
-      return new XJogChart<
-        TContext,
-        TStateSchema,
-        TEvent,
-        TTypeState,
-        TEmitted
-      >(
-        xJogMachine,
-        chartId,
-        parentRef,
-        state,
-        resolveXJogChartOptions(xJogMachine.xJog.options, xJogMachine.options),
-      );
+        return new XJogChart<
+          TContext,
+          TStateSchema,
+          TEvent,
+          TTypeState,
+          TEmitted
+        >(
+          xJogMachine,
+          chartId,
+          parentRef,
+          state,
+          resolveXJogChartOptions(xJogMachine.xJog.options, xJogMachine.options),
+        );
+      }
+      return null;
     });
   }
 

--- a/packages/core/src/XJogMachine.ts
+++ b/packages/core/src/XJogMachine.ts
@@ -175,7 +175,7 @@ export class XJogMachine<
   public async getChart(
     chartId: string,
     cid = getCorrelationIdentifier(),
-  ): Promise<XJogChart<TContext, TStateSchema, TEvent, TTypeState>> {
+  ): Promise<XJogChart<TContext, TStateSchema, TEvent, TTypeState> | null> {
     const logPayload = { in: 'getChart', cid, chartId };
 
     const trace = (...args: Array<string | Record<string, unknown>>) =>
@@ -204,15 +204,16 @@ export class XJogMachine<
         if (!chart) {
           debug('Failed to load');
           await this.evictCacheEntry(chartId, false);
+        } else {
+          await this.refreshCache(chart, false);
+
+          trace({ message: 'Done' });
+          return chart;
         }
-
-        await this.refreshCache(chart, false);
-
-        trace({ message: 'Done' });
-        return chart;
       } finally {
         releaseMutex();
       }
+      return null;
     });
   }
 

--- a/packages/core/src/XJogMachine.ts
+++ b/packages/core/src/XJogMachine.ts
@@ -175,7 +175,7 @@ export class XJogMachine<
   public async getChart(
     chartId: string,
     cid = getCorrelationIdentifier(),
-  ): Promise<XJogChart<TContext, TStateSchema, TEvent, TTypeState> | null> {
+  ): Promise<XJogChart<TContext, TStateSchema, TEvent, TTypeState>> {
     const logPayload = { in: 'getChart', cid, chartId };
 
     const trace = (...args: Array<string | Record<string, unknown>>) =>
@@ -204,7 +204,6 @@ export class XJogMachine<
         if (!chart) {
           debug('Failed to load');
           await this.evictCacheEntry(chartId, false);
-          return null;
         }
 
         await this.refreshCache(chart, false);

--- a/packages/util/src/ChartNotFoundError.ts
+++ b/packages/util/src/ChartNotFoundError.ts
@@ -1,0 +1,8 @@
+import { ChartReference } from './ChartReference';
+
+export class ChartNotFoundError extends Error {
+  constructor(ref: ChartReference, message?: string) {
+    super(`MachineId: ${ref.machineId}, chartId: ${ref.chartId}${message ? ` - ${message}` : ''}`);
+    this.name = 'ChartNotFoundError';
+  }
+}

--- a/packages/util/src/MachineNotFoundError.ts
+++ b/packages/util/src/MachineNotFoundError.ts
@@ -1,0 +1,6 @@
+export class MachineNotFoundError extends Error {
+  constructor(machineId: string, message?: string) {
+    super(`MachineId: ${machineId}${message ? ` - ${message}` : ''}`);
+    this.name = 'MachineNotFoundError';
+  }
+}

--- a/packages/util/src/index.ts
+++ b/packages/util/src/index.ts
@@ -1,3 +1,4 @@
+export * from './ChartNotFoundError';
 export * from './ChartReference';
 export * from './ChartIdentifier';
 export * from './ActivityRef';

--- a/packages/util/src/index.ts
+++ b/packages/util/src/index.ts
@@ -1,6 +1,7 @@
 export * from './ChartNotFoundError';
 export * from './ChartReference';
 export * from './ChartIdentifier';
+export * from './MachineNotFoundError';
 export * from './ActivityRef';
 export * from './XJogStateChange';
 export * from './XJogActionTypes';


### PR DESCRIPTION
* Throw ChartNotFoundError when chart is not found in database
* Functionality to retrieve machine ID by chart ID. If machine ID is not found, throw MachineNotFoundError.